### PR TITLE
reorder query lines in libssh2_eating_error_codes

### DIFF
--- a/ql_demos/cpp/libssh2_eating_error_codes/01_error_codes_call.ql
+++ b/ql_demos/cpp/libssh2_eating_error_codes/01_error_codes_call.ql
@@ -6,9 +6,8 @@ import cpp
 
 // Extend the previous query to also find calls to functions that sometimes
 // return a negative integer constant.
-from Function f, FunctionCall call, ReturnStmt ret
+from FunctionCall call, ReturnStmt ret
 where
   ret.getExpr().getValue().toInt() < 0 and
-  ret.getEnclosingFunction() = f and
-  call.getTarget() = f
+  call.getTarget() = ret.getEnclosingFunction()
 select ret, call

--- a/ql_demos/cpp/libssh2_eating_error_codes/02_eating_error_codes.ql
+++ b/ql_demos/cpp/libssh2_eating_error_codes/02_eating_error_codes.ql
@@ -6,10 +6,9 @@ import cpp
 
 // Look for calls that are cast to unsigned, which means that the error
 // code might be accidentally ignored.
-from Function f, FunctionCall call, ReturnStmt ret
+from FunctionCall call, ReturnStmt ret
 where
   ret.getExpr().getValue().toInt() < 0 and
-  ret.getEnclosingFunction() = f and
-  call.getTarget() = f and
+  call.getTarget() = ret.getEnclosingFunction() and
   call.getFullyConverted().getType().getUnderlyingType().(IntegralType).isUnsigned()
 select call, ret

--- a/ql_demos/cpp/libssh2_eating_error_codes/03_eating_error_codes_localflow.ql
+++ b/ql_demos/cpp/libssh2_eating_error_codes/03_eating_error_codes_localflow.ql
@@ -14,11 +14,10 @@ import semmle.code.cpp.dataflow.DataFlow
 //
 // In this query, we add local dataflow so that we can also handle such
 // cases.
-from Function f, FunctionCall call, ReturnStmt ret, DataFlow::Node source, DataFlow::Node sink
+from FunctionCall call, ReturnStmt ret, DataFlow::Node source, DataFlow::Node sink
 where
   ret.getExpr().getValue().toInt() < 0 and
-  ret.getEnclosingFunction() = f and
-  call.getTarget() = f and
+  call.getTarget() = ret.getEnclosingFunction() and
   source.asExpr() = call and
   DataFlow::localFlow(source, sink) and
   sink.asExpr().getFullyConverted().getType().getUnderlyingType().(IntegralType).isUnsigned()

--- a/ql_demos/cpp/libssh2_eating_error_codes/04_eating_error_codes_localflow_rangeanalysis.ql
+++ b/ql_demos/cpp/libssh2_eating_error_codes/04_eating_error_codes_localflow_rangeanalysis.ql
@@ -18,11 +18,10 @@ import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 //   int r = f();
 //   if (r < 0) return -1;
 //   unsigned int x = r;
-from Function f, FunctionCall call, ReturnStmt ret, DataFlow::Node source, DataFlow::Node sink
+from FunctionCall call, ReturnStmt ret, DataFlow::Node source, DataFlow::Node sink
 where
   ret.getExpr().getValue().toInt() < 0 and
-  ret.getEnclosingFunction() = f and
-  call.getTarget() = f and
+  call.getTarget() = ret.getEnclosingFunction() and
   source.asExpr() = call and
   DataFlow::localFlow(source, sink) and
   sink.asExpr().getFullyConverted().getType().getUnderlyingType().(IntegralType).isUnsigned() and


### PR DESCRIPTION
I think this Improves readability of the query.
I've also reformatted the third query in order to bring it in line with the others.

@kevinbackhouse 