### PR TITLE
Fix Fizz query

### DIFF
--- a/ql_demos/cpp/Facebook_Fizz_CVE-2019-3560/FizzOverflow.ql
+++ b/ql_demos/cpp/Facebook_Fizz_CVE-2019-3560/FizzOverflow.ql
@@ -27,13 +27,21 @@ class Cfg extends TaintTracking::Configuration {
 
   /** Holds if `source` is a call to `Endian::big()`. */
   override predicate isSource(DataFlow::Node source) {
-    source.(CallInstruction).getCallTarget().(FunctionInstruction).getFunctionSymbol() instanceof
-      EndianConvert
+    source
+        .asInstruction()
+        .(CallInstruction)
+        .getCallTarget()
+        .(FunctionInstruction)
+        .getFunctionSymbol() instanceof EndianConvert
   }
 
   /** Hold if `sink` is a narrowing conversion. */
   override predicate isSink(DataFlow::Node sink) {
-    sink.getResultSize() < sink.(ConvertInstruction).getUnary().getResultSize()
+    sink.asInstruction().getResultSize() < sink
+          .asInstruction()
+          .(ConvertInstruction)
+          .getUnary()
+          .getResultSize()
   }
 }
 
@@ -42,7 +50,7 @@ from
   Type inputType, Type outputType
 where
   cfg.hasFlowPath(source, sink) and
-  conv = sink.getNode() and
+  conv = sink.getNode().asInstruction() and
   inputType = conv.getUnary().getResultType() and
   outputType = conv.getResultType()
 select sink, source, sink,


### PR DESCRIPTION
Fix Fizz query after a backwards-incompatible change happened in the IR dataflow library.
See https://discuss.lgtm.com/t/the-fizz-example-doesnt-work/2384
The backwards-incompatible change happened here: https://github.com/Semmle/ql/pull/1888